### PR TITLE
Compatibility with Airflow 1.10 & 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apt-get update -yqq \
 
 RUN pip install --upgrade pip
 
+# Symbolic link necessary for the apache-airflow-backport-providers-* packages
+RUN ln -s /usr/local/lib/python3.7/site-packages/airflow/providers /home/airflow/.local/lib/python3.7/site-packages/airflow/
+
 COPY ./requirements.txt /requirements.txt
 #RUN pip install -r /requirements.txt
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,14 @@ See https://python-poetry.org/docs/#osx-linux-bashonwindows-install-instructions
 
 ## Install the dependencies
 
-`poetry install`
+
+You can automatically install the required dependencies by running
+
+```bash
+poetry install
+```
+
+This will install Airflow 2 by default. If you want to configure Airflow version, edit the `pyproject.toml` file.
 
 ## Prepare your environment to run the tests
 
@@ -270,20 +277,32 @@ psql -U user -W -h localhost -f tests/fixtures/load_postgres.sql -d viewflow
 
 ### Run Pytest
 
-Before you can run the following command, you will have to have an Airflow SQLite database.
-Run
+Before you can continue, you will need to set up an Airflow SQLite database.
 
-`poetry run airflow initdb`
-
-then,
-
-`poetry run pytest`
-
-Other useful commands include:
 
 ```bash
-poetry run airflow resetdb # In case the database connection is set up incorrectly
+poetry run airflow db init # Airflow 2
+poetry run airflow initdb # Airflow 1.10
 ```
+
+Note: when you're using Airflow 1.10.12 and you get an `ImportError`, it can be helpful to refer to this [post](https://stackoverflow.com/questions/64891058/issue-on-airflow-initdb). E.g. for Python 3.8, reinstall Airflow with
+
+`pip install apache-airflow==1.10.12 --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-1.10.12/constraints-3.8.txt"`
+
+After setting up the database, run
+
+```bash
+poetry run pytest
+```
+
+
+In case the database connection is set up incorrectly, run
+
+```bash
+poetry run airflow db reset # Airflow 2
+poetry run airflow resetdb # Airflow 1.10
+```
+
 ## Viewflow architecture
 
 We built Viewflow around three main components: the *parser*, the *adapter*, and the *dependency extractor*.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,13 @@ sqlalchemy = "<1.4.0"
 
 # Option 1: apache-airflow >= 2.0.0
 # ------------------------------------
-apache-airflow = "^2.0.0"
-apache-airflow-providers-postgres = "^2.0.0"
+# apache-airflow = "^2.0.0"
+# apache-airflow-providers-postgres = "^2.0.0"
 
 # Option 2: apache-airflow <= 1.10.15
 # ------------------------------------
-# apache-airflow = "1.10.12"
-# apache-airflow-backport-providers-postgres = "^2021.3.17"
+apache-airflow = "1.10.14"
+apache-airflow-backport-providers-postgres = "^2021.3.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-apache-airflow = "1.10.14"
+apache-airflow = "2.1.1"
 psycopg2 = "^2.8.5"
 numpy = "^1.19.1"
 pandas = ">=1.1"
@@ -16,6 +16,7 @@ fsspec = "^0.8.0"
 ratelimit = "^2.2.1"
 networkx = "^2.5"
 sqlalchemy = "<1.4.0"
+apache-airflow-providers-postgres = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ sqlalchemy = "<1.4.0"
 
 # Option 1: apache-airflow >= 2.0.0
 # ------------------------------------
-apache-airflow = "2.1.1"
+apache-airflow = "^2.0.0"
 apache-airflow-providers-postgres = "^2.0.0"
 
 # Option 2: apache-airflow <= 1.10.15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-apache-airflow = "1.10.12"
 psycopg2 = "^2.8.5"
 numpy = "^1.19.1"
 pandas = ">=1.1"
@@ -16,10 +15,16 @@ fsspec = "^0.8.0"
 ratelimit = "^2.2.1"
 networkx = "^2.5"
 sqlalchemy = "<1.4.0"
-apache-airflow-backport-providers-postgres = "^2021.3.17"
 
-# Only required if apache-airflow >= 2.0.0
-# apache-airflow-providers-postgres = "^2.0.0"
+# Option 1: apache-airflow >= 2.0.0
+# ------------------------------------
+apache-airflow = "2.1.1"
+apache-airflow-providers-postgres = "^2.0.0"
+
+# Option 2: apache-airflow <= 1.10.15
+# ------------------------------------
+# apache-airflow = "1.10.12"
+# apache-airflow-backport-providers-postgres = "^2021.3.17"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.7"
-apache-airflow = "2.1.1"
+apache-airflow = "1.10.12"
 psycopg2 = "^2.8.5"
 numpy = "^1.19.1"
 pandas = ">=1.1"
@@ -16,7 +16,10 @@ fsspec = "^0.8.0"
 ratelimit = "^2.2.1"
 networkx = "^2.5"
 sqlalchemy = "<1.4.0"
-apache-airflow-providers-postgres = "^2.0.0"
+apache-airflow-backport-providers-postgres = "^2021.3.17"
+
+# Only required if apache-airflow >= 2.0.0
+# apache-airflow-providers-postgres = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.5.8
 apache-airflow==1.10.14
+apache-airflow-backport-providers-postgres==2021.3.17
 apispec==1.3.3; python_version >= "3.6"
 argcomplete==1.12.2
 attrs==20.3.0

--- a/viewflow/adapters/postgresql/postgres_adapter.py
+++ b/viewflow/adapters/postgresql/postgres_adapter.py
@@ -2,7 +2,7 @@ import os
 from jinja2 import Template
 from pathlib import Path
 from typing import Dict, Any
-from airflow.operators.postgres_operator import PostgresOperator  # type: ignore
+from airflow.providers.postgres.operators.postgres import PostgresOperator # type: ignore
 from airflow.models import BaseOperator
 from ..post_execute_monkey_patch import monkey_post_execute
 

--- a/viewflow/operators/python_to_postgres_operator.py
+++ b/viewflow/operators/python_to_postgres_operator.py
@@ -4,7 +4,7 @@ import logging
 import pandas as pd
 from datetime import date
 from airflow.hooks.postgres_hook import PostgresHook
-from airflow.operators import BaseOperator
+from airflow.models import BaseOperator
 
 
 def get_function(func_module_directory, func):
@@ -30,9 +30,10 @@ class PythonToPostgresOperator(BaseOperator):
         owner,
         schema,
         dependencies,
+        default_args={}
     ):
 
-        super(PythonToPostgresOperator, self).__init__(task_id=task_id, email=email)
+        super(PythonToPostgresOperator, self).__init__(task_id=task_id, email=email, default_args=default_args)
         self.conn_id = conn_id
         self.callable = callable
         self.python_dir = python_dir


### PR DESCRIPTION
The tests now run successfully on mulitple Airflow versions. I tested Airflow 1.10.12 and 2.1.1

There are still a few remaining warnings, but they are caused by the other packages that are used. If using Airflow 2, there's only 1 warning caused by the sqlalchemy package.

The README.md file is also updated to contain valid instructions for Airflow versions 1.10.12 through 2.1.1.