### PR TITLE
Callbacks for tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ In `$AIRFLOW_HOME/dags/`, create a directory called `my-first-viewflow-dag`. In 
 
 ```yml
 default_args:
-    owner: <owner>@dag.com
+    owner: <email>
     retries: 1
 schedule_interval: 0 6 * * *
 start_date: "2021-01-01"
@@ -200,7 +200,7 @@ A SQL view is created by a SQL file. This SQL file must contain the SQL query (a
 ```sql
 /* 
 ---
-owner: name-of-the-view-owner
+owner: email address of the view owner
 description: A description of your view. It's used as the view's description in the database
 fields:
   email: Description of your column -- used as the view column's description in the database
@@ -226,7 +226,7 @@ import pandas as pd
 def python_view(db_engine):
     """
     ---
-    owner: name-of-the-view-owner
+    owner: email address of the view owner
     description: A description of your view. It's used as the view's description in the database
     fields:
         email: Description of your column -- used as the view column's description in the database

--- a/README.md
+++ b/README.md
@@ -240,6 +240,28 @@ def python_view(db_engine):
 
 Please note that Viewflow expects the Python function that creates the view to have the parameter `db_engine` (used to connect to the database). You don't have to set `db_engine` anywhere. Viewflow takes care of setting this variable.
 
+## Configuring callbacks
+A useful feature is enabling callbacks when a task succeeds, fails, or is retried. This callback can take many forms, e.g. an email or a Slack message. Viewflow allows you to define your own callbacks in [viewflow/task_callbacks.py](./viewflow/task_callbacks.py). These callbacks can be configured on multiple levels:
+1. By default, certain functions defined in [viewflow/task_callbacks.py](./viewflow/task_callbacks.py) are used (e.g. `on_success_callback_default`).
+2. The callbacks can be overwritten for all tasks in a given DAG. E.g. if you have defined 3 custom callback functions in [viewflow/task_callbacks.py](./viewflow/task_callbacks.py), you can specify them in the DAG's `config.yml` file as following:
+
+```yaml
+default_args:
+  on_success_callback: on_success_callback_custom
+  on_failure_callback: on_failure_callback_custom
+  on_retry_callback: on_retry_callback_custom
+```
+
+3. For the highest level of configurability, you can overwrite the callbacks for a specific task. This option is prioritized, it doesn't matter whether there are callbacks specified in the DAG's `config.yml` file. The callback functions can simply be added to the metadata of the task's script:
+
+```yaml
+on_success_callback: on_success_callback_custom
+on_failure_callback: on_failure_callback_custom
+on_retry_callback: on_retry_callback_custom
+```
+
+Of course, options 1, 2 and 3 can be combined to efficiently configure the callbacks of a multitude of tasks.
+
 # Contributing to Viewflow
 
 We welcome all sorts of contributions, be it new features, bug fixes or documentation, we encourage you to create a new PR. To create a new PR or to report new bugs, please read how to [contribute to Viewflow](CONTRIBUTION.md). 

--- a/demo/dags/viewflow-demo-1/course_enriched.sql
+++ b/demo/dags/viewflow-demo-1/course_enriched.sql
@@ -1,6 +1,6 @@
 /*
 ---
-owner: viewflow-team
+owner: data@datacamp.com
 description: Enriched the course table
 fields:
   course_id: The course id

--- a/demo/dags/viewflow-demo-1/top_3_user_xp.py
+++ b/demo/dags/viewflow-demo-1/top_3_user_xp.py
@@ -3,7 +3,7 @@ import pandas as pd
 def top_3_user_xp(db_engine):
     """
     ---
-    owner: viewflow-team
+    owner: data@datacamp.com
     description: Provide the top 3 users with the most XP.
     fields:
         user_id: The user id

--- a/demo/dags/viewflow-demo-1/user_xp.sql
+++ b/demo/dags/viewflow-demo-1/user_xp.sql
@@ -1,6 +1,6 @@
 /*
 ---
-owner: viewflow-team
+owner: data@datacamp.com
 description: Provide the total amount of XP for each user
 fields:
   user_id: The user id

--- a/demo/dags/viewflow-demo-2/user_enriched.sql
+++ b/demo/dags/viewflow-demo-2/user_enriched.sql
@@ -1,6 +1,6 @@
 /*
 ---
-owner: viewflow-team
+owner: data@datacamp.com
 description: A table with enriched information of users
 fields:
   user_id: The user id

--- a/demo/dags/viewflow-demo-3/user_xp_duplicate.R
+++ b/demo/dags/viewflow-demo-3/user_xp_duplicate.R
@@ -1,5 +1,5 @@
 # ---
-# owner: viewflow-team
+# owner: data@datacamp.com
 # description: Provide the total amount of XP for each user
 # fields:
 #   user_id: The user id

--- a/demo/dags/viewflow-demo-4/top_3_user_xp_duplicate.Rmd
+++ b/demo/dags/viewflow-demo-4/top_3_user_xp_duplicate.Rmd
@@ -1,5 +1,5 @@
 ---
-owner: viewflow-team
+owner: data@datacamp.com
 description: Provide the top 3 users with the most XP.
 fields:
   user_id: The user id

--- a/tests/parsers/test_parse_r.py
+++ b/tests/parsers/test_parse_r.py
@@ -9,7 +9,7 @@ def test_parse_r():
         'connection_id': 'postgres_demo',
         'description': 'Provide the total amount of XP for each user',
         'fields': {'user_id': 'The user id', 'xp': 'The sum of XP'},
-        'owner': 'viewflow-team',
+        'owner': 'data@datacamp.com',
         'schema': 'viewflow_demo',
         'task_file_path': 'tests/projects/r/task_1.R',
         'type': 'ROperator',

--- a/tests/parsers/test_parse_rmd.py
+++ b/tests/parsers/test_parse_rmd.py
@@ -10,7 +10,7 @@ def test_parse_rmd():
         'content': '\n## Title 1\nSection 1\n```{r rename_view}\nuser_xp <- viewflow_demo.user_xp\n```\n\n## Title 2\nSection 2\n```{r create_view}\ntop_3_user_xp_duplicate <- head(user_xp[order(user_xp$xp, decreasing=TRUE),], n = 3)\n```\n',
         'description': 'Provide the top 3 users with the most XP.',
         'fields': {'user_id': 'The user id', 'xp': 'The user amount of XP'},
-        'owner': 'viewflow-team',
+        'owner': 'data@datacamp.com',
         'schema': 'viewflow_demo',
         'task_file_path': 'tests/projects/rmd/task_1.Rmd',
         'type': 'RmdOperator'

--- a/tests/projects/dag_callbacks/config.yml
+++ b/tests/projects/dag_callbacks/config.yml
@@ -1,0 +1,8 @@
+# ignore nonsensical default callbacks, it's for testing purposes
+default_args:
+  owner:  data@datacamp.com
+  on_failure_callback: on_failure_callback_email
+  on_success_callback: on_failure_callback_email
+  on_retry_callback: on_failure_callback_email
+schedule_interval: 0 5 * * *
+start_date: "2020-04-29"

--- a/tests/projects/dag_callbacks/task_1.yml
+++ b/tests/projects/dag_callbacks/task_1.yml
@@ -1,0 +1,11 @@
+owner: engineering@datacamp.com
+type: PostgresOperator
+description: This is a very simple task.
+fields:
+  id: This is the ID.
+tags:
+  - cool
+  - new
+content: |-
+  SELECT test FROM some_table
+schema: viewflow

--- a/tests/projects/dag_callbacks/task_2.yml
+++ b/tests/projects/dag_callbacks/task_2.yml
@@ -1,0 +1,15 @@
+owner: engineering@datacamp.com
+type: PostgresOperator
+description: This is a very simple task with custom callbacks.
+fields:
+  id: This is the ID.
+tags:
+  - cool
+  - new
+content: |-
+  SELECT test FROM some_table
+schema: viewflow
+# ignore nonsensical callbacks, it's for testing purposes
+on_failure_callback: on_success_callback_default
+on_success_callback: on_retry_callback_default
+on_retry_callback: on_failure_callback_default

--- a/tests/projects/r/pattern_default/user_emails.R
+++ b/tests/projects/r/pattern_default/user_emails.R
@@ -6,9 +6,9 @@
 #   email: Email address
 # schema: viewflow
 # connection_id: postgres_viewflow
-# on_success_callback: failure_callback_email
-# on_retry_callback: failure_callback_email
-# on_failure_callback: failure_callback_email
+# on_success_callback: on_failure_callback_email
+# on_retry_callback: on_failure_callback_email
+# on_failure_callback: on_failure_callback_email
 # ---
 
 user_emails = select(viewflow.users, c("user_id", "email"))

--- a/tests/projects/r/pattern_default/user_emails.R
+++ b/tests/projects/r/pattern_default/user_emails.R
@@ -6,6 +6,9 @@
 #   email: Email address
 # schema: viewflow
 # connection_id: postgres_viewflow
+# on_success_callback: failure_callback_email
+# on_retry_callback: failure_callback_email
+# on_failure_callback: failure_callback_email
 # ---
 
 user_emails = select(viewflow.users, c("user_id", "email"))

--- a/tests/projects/r/task_1.R
+++ b/tests/projects/r/task_1.R
@@ -1,5 +1,5 @@
 # ---
-# owner: viewflow-team
+# owner: data@datacamp.com
 # description: Provide the total amount of XP for each user
 # fields:
 #   user_id: The user id

--- a/tests/projects/rmd/default_config/user_emails.Rmd
+++ b/tests/projects/rmd/default_config/user_emails.Rmd
@@ -8,7 +8,11 @@ schema: viewflow
 connection_id: postgres_viewflow
 ---
 
-## Straightforward execution
+## Straightforward execution of this script
+Dependencies are retrieved based on the default pattern: <schema_name>.<table_name>
+This enables Viewflow to construct a valid DAG.
+However, it's your responsibility to make sure the tables are read from the database!
+
 ```{r}
-myString <- "Hello World!"
+user_emails = select(viewflow.users, c("user_id", "email"))
 ```

--- a/tests/projects/rmd/task_1.Rmd
+++ b/tests/projects/rmd/task_1.Rmd
@@ -1,5 +1,5 @@
 ---
-owner: viewflow-team
+owner: data@datacamp.com
 description: Provide the top 3 users with the most XP.
 fields:
   user_id: The user id

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,19 +1,37 @@
 from viewflow.create_dag import create_dag
-from viewflow.task_callbacks import success_callback_default, retry_callback_default, failure_callback_default, failure_callback_email
+from viewflow.task_callbacks import on_success_callback_default, on_retry_callback_default, on_failure_callback_default, on_failure_callback_email
 
 def test_default_callbacks():
     dag = create_dag("./tests/projects/postgresql/simple_dag")
     task = dag.get_task("task_1")
 
-    assert task.on_success_callback == success_callback_default
-    assert task.on_retry_callback == retry_callback_default
-    assert task.on_failure_callback == failure_callback_default
+    assert task.on_success_callback == on_success_callback_default
+    assert task.on_retry_callback == on_retry_callback_default
+    assert task.on_failure_callback == on_failure_callback_default
 
 
 def test_custom_callbacks():
+    """No DAG defaults, but task has specified callbacks."""
     dag = create_dag("./tests/projects/r/pattern_default")
     task = dag.get_task("user_emails")
 
-    assert task.on_success_callback == failure_callback_email
-    assert task.on_retry_callback == failure_callback_email
-    assert task.on_failure_callback == failure_callback_email
+    assert task.on_success_callback == on_failure_callback_email
+    assert task.on_retry_callback == on_failure_callback_email
+    assert task.on_failure_callback == on_failure_callback_email
+
+
+def test_dag_defaults_callbacks():
+    """DAG has default callbacks, but these can be overwritten by individual tasks."""
+    dag = create_dag("./tests/projects/dag_callbacks") # The DAG has specified default callbacks
+    task1 = dag.get_task("task_1")
+    task2 = dag.get_task("task_2")
+
+    # Task 1 must have the DAG's default callbacks
+    assert task1.on_success_callback == on_failure_callback_email
+    assert task1.on_retry_callback == on_failure_callback_email
+    assert task1.on_failure_callback == on_failure_callback_email
+
+    # Task 2 must have the task's specific callbacks
+    assert task2.on_failure_callback == on_success_callback_default
+    assert task2.on_success_callback == on_retry_callback_default
+    assert task2.on_retry_callback == on_failure_callback_default

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,19 @@
+from viewflow.create_dag import create_dag
+from viewflow.task_callbacks import success_callback_default, retry_callback_default, failure_callback_default, failure_callback_email
+
+def test_default_callbacks():
+    dag = create_dag("./tests/projects/postgresql/simple_dag")
+    task = dag.get_task("task_1")
+
+    assert task.on_success_callback == success_callback_default
+    assert task.on_retry_callback == retry_callback_default
+    assert task.on_failure_callback == failure_callback_default
+
+
+def test_custom_callbacks():
+    dag = create_dag("./tests/projects/r/pattern_default")
+    task = dag.get_task("user_emails")
+
+    assert task.on_success_callback == failure_callback_email
+    assert task.on_retry_callback == failure_callback_email
+    assert task.on_failure_callback == failure_callback_email

--- a/viewflow/create_dag.py
+++ b/viewflow/create_dag.py
@@ -13,6 +13,7 @@ from typing import Dict, Any, TypeVar
 from airflow import DAG  # type: ignore
 from airflow.models import BaseOperator  # type: ignore
 from airflow.sensors.external_task_sensor import ExternalTaskSensor  # type: ignore
+from .task_callbacks import success_callback, failure_callback, retry_callback
 
 from .adapters.postgresql import postgres_adapter
 from .adapters.python import python_adapter
@@ -203,6 +204,10 @@ def create_task(parsed_task: Dict[str, Any], operators=OPERATORS) -> O:
         return None
     task = adapter(parsed_task)
 
+    task.on_success_callback = success_callback
+    task.on_failure_callback = failure_callback
+    task.on_retry_callback = retry_callback
+    
     return task
 
 

--- a/viewflow/create_dag.py
+++ b/viewflow/create_dag.py
@@ -13,7 +13,7 @@ from typing import Dict, Any, TypeVar
 from airflow import DAG  # type: ignore
 from airflow.models import BaseOperator  # type: ignore
 from airflow.sensors.external_task_sensor import ExternalTaskSensor  # type: ignore
-from .task_callbacks import success_callback, failure_callback, retry_callback
+from .task_callbacks import success_callback_default, failure_callback_default, retry_callback_default
 
 from .adapters.postgresql import postgres_adapter
 from .adapters.python import python_adapter
@@ -204,9 +204,9 @@ def create_task(parsed_task: Dict[str, Any], operators=OPERATORS) -> O:
         return None
     task = adapter(parsed_task)
 
-    task.on_success_callback = success_callback
-    task.on_failure_callback = failure_callback
-    task.on_retry_callback = retry_callback
+    task.on_success_callback = success_callback_default
+    task.on_failure_callback = failure_callback_default
+    task.on_retry_callback = retry_callback_default
     
     return task
 

--- a/viewflow/create_dag.py
+++ b/viewflow/create_dag.py
@@ -133,8 +133,6 @@ def set_callbacks(created_task, parsed_task):
     """Set the task-specific callbacks if given any.
     Use default callbacks if neither the DAG's config.yml nor the task specifies callbacks."""
 
-    
-
     for callback_type in ["on_success_callback", "on_failure_callback", "on_retry_callback"]:
         # The callback at this point is the one that is specified in the DAG's config.yml
         # However, it is a string... We convert the string to a function

--- a/viewflow/create_dag.py
+++ b/viewflow/create_dag.py
@@ -13,7 +13,7 @@ from typing import Dict, Any, TypeVar
 from airflow import DAG  # type: ignore
 from airflow.models import BaseOperator  # type: ignore
 from airflow.sensors.external_task_sensor import ExternalTaskSensor  # type: ignore
-import task_callbacks
+from . import task_callbacks
 
 from .adapters.postgresql import postgres_adapter
 from .adapters.python import python_adapter
@@ -204,15 +204,9 @@ def create_task(parsed_task: Dict[str, Any], operators=OPERATORS) -> O:
         return None
     task = adapter(parsed_task)
 
-    task.on_success_callback = \
-        getattr(task_callbacks, parsed_task.get("on_success_callback")) if parsed_task.has("on_success_callback") else \
-        task_callbacks.success_callback_default
-    task.on_failure_callback = \
-        getattr(task_callbacks, parsed_task.get("on_failure_callback")) if parsed_task.has("on_failure_callback") else \
-        task_callbacks.failure_callback_default
-    task.on_retry_callback = \
-        getattr(task_callbacks, parsed_task.get("on_retry_callback")) if parsed_task.has("on_retry_callback") else \
-        task_callbacks.retry_callback_default
+    task.on_success_callback = getattr(task_callbacks, parsed_task.get("on_success_callback", "success_callback_default"))
+    task.on_failure_callback = getattr(task_callbacks, parsed_task.get("on_failure_callback", "failure_callback_default"))
+    task.on_retry_callback = getattr(task_callbacks, parsed_task.get("on_retry_callback", "retry_callback_default"))
     
     return task
 

--- a/viewflow/task_callbacks.py
+++ b/viewflow/task_callbacks.py
@@ -1,20 +1,34 @@
+from datetime import datetime
+from airflow.utils.email import send_email
 
 
-def success_callback(airflow_context):
+def success_callback_default(airflow_context):
     pass
 
 
-def retry_callback(airflow_context):
+def retry_callback_default(airflow_context):
     pass
 
 
-def failure_callback(airflow_context):
+def failure_callback_default(airflow_context):
+    pass
+
+
+def failure_callback_email(airflow_context):
+    """Send an email to the owner of the failed task.
+    Note that you first have to configure the email settings in $AIRFLOW_HOME/airflow.cfg"""
     info = {
-        "task": airflow_context.get('task_instance').task_id,
-        "dag": airflow_context.get('task_instance').dag_id,
+        "task": airflow_context.get("task_instance").task_id,
+        "dag": airflow_context.get("task_instance").dag_id,
         "owner": airflow_context["task"].owner,
-        "execution_time": airflow_context.get('execution_date'),
-        "URL_logs": {airflow_context.get('task_instance').log_url}
+        "execution_time": airflow_context.get("execution_date"),
+        "URL_logs": {airflow_context.get("task_instance").log_url}
     }
-    # TODO send email
+    
+    recipient_emails=[airflow_context["task"].owner]
+
+    title = ''
+    body = ''
+
+    send_email(recipient_emails, title, body)
 

--- a/viewflow/task_callbacks.py
+++ b/viewflow/task_callbacks.py
@@ -1,0 +1,20 @@
+
+
+def success_callback(airflow_context):
+    pass
+
+
+def retry_callback(airflow_context):
+    pass
+
+
+def failure_callback(airflow_context):
+    info = {
+        "task": airflow_context.get('task_instance').task_id,
+        "dag": airflow_context.get('task_instance').dag_id,
+        "owner": airflow_context["task"].owner,
+        "execution_time": airflow_context.get('execution_date'),
+        "URL_logs": {airflow_context.get('task_instance').log_url}
+    }
+    # TODO send email
+

--- a/viewflow/task_callbacks.py
+++ b/viewflow/task_callbacks.py
@@ -1,20 +1,19 @@
-from datetime import datetime
 from airflow.utils.email import send_email
 from textwrap import dedent
 
-def success_callback_default(airflow_context):
+def on_success_callback_default(airflow_context):
     pass
 
 
-def retry_callback_default(airflow_context):
+def on_retry_callback_default(airflow_context):
     pass
 
 
-def failure_callback_default(airflow_context):
+def on_failure_callback_default(airflow_context):
     pass
 
 
-def failure_callback_email(airflow_context):
+def on_failure_callback_email(airflow_context):
     """Send an email to the owner of the failed task.
     Note that you first have to configure the email (SMTP) settings in $AIRFLOW_HOME/airflow.cfg"""
 

--- a/viewflow/task_callbacks.py
+++ b/viewflow/task_callbacks.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from airflow.utils.email import send_email
-
+from textwrap import dedent
 
 def success_callback_default(airflow_context):
     pass
@@ -16,19 +16,16 @@ def failure_callback_default(airflow_context):
 
 def failure_callback_email(airflow_context):
     """Send an email to the owner of the failed task.
-    Note that you first have to configure the email settings in $AIRFLOW_HOME/airflow.cfg"""
-    info = {
-        "task": airflow_context.get("task_instance").task_id,
-        "dag": airflow_context.get("task_instance").dag_id,
-        "owner": airflow_context["task"].owner,
-        "execution_time": airflow_context.get("execution_date"),
-        "URL_logs": {airflow_context.get("task_instance").log_url}
-    }
-    
-    recipient_emails=[airflow_context["task"].owner]
+    Note that you first have to configure the email (SMTP) settings in $AIRFLOW_HOME/airflow.cfg"""
 
-    title = ''
-    body = ''
+    title = f"""Airflow failed task: {airflow_context.get("task_instance").task_id}"""
+    body = dedent(f"""
+    DAG:            {airflow_context.get("task_instance").dag_id}
+    Task:           {airflow_context.get("task_instance").task_id}
+    Owner:          {airflow_context.get("task").owner}
+    Execution time: {airflow_context.get("execution_date")}
+    URL logs:       {airflow_context.get("task_instance").log_url}
+    """)
 
+    recipient_emails = [airflow_context["task"].owner]
     send_email(recipient_emails, title, body)
-


### PR DESCRIPTION
A description of the new functionality is added to the README under the subtitle 'Configuring callbacks'.
In a nutshell, any number of callback functions can be defined  viewflow/task_callbacks.py
The default callbacks can be overwritten on the DAG-level, but also for a specific task.

The functionality has been tested successfully (in tests/test_callbacks.py).